### PR TITLE
Fix root indexes file writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,19 +137,16 @@ const run = async () => {
     await createOrAppendSiteIndex(
       TRACKS_INDEX,
       TRACKS_SITE_MAP_ROOT,
-      getLatestSiteMapNumber(latestTrack),
       latestTrackNumber
     )
     await createOrAppendSiteIndex(
       COLLECTIONS_INDEX,
       COLLECTIONS_SITE_MAP_ROOT,
-      getLatestSiteMapNumber(latestCollection),
       latestCollectionNumber
     )
     await createOrAppendSiteIndex(
       USERS_INDEX,
       USERS_SITE_MAP_ROOT,
-      getLatestSiteMapNumber(latestUser),
       latestUserNumber
     )
 

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -107,7 +107,7 @@ const createRootSiteIndex = async (path, tracksIndex, collectionsIndex, usersInd
   )
 
   const xml = create(index).end({ prettyPrint: true })
-  fs.writeFile(path, xml, () => {})
+  fs.writeFileSync(path, xml)
 }
 
 /**
@@ -175,7 +175,7 @@ const createOrAppendSiteMap = async (urls, latestSiteMapNumber, siteMapRoot) => 
   maps.forEach((map, i) => {
     const path = paths[i]
     const xml = create(map).end({ prettyPrint: true })
-    fs.writeFile(path, xml, () => {})
+    fs.writeFileSync(path, xml)
   })
 
   return siteMapNumber
@@ -197,44 +197,22 @@ const createOrAppendSiteMap = async (urls, latestSiteMapNumber, siteMapRoot) => 
  *
  * @param {string} path path to write the index to
  * @param {string} siteMapRoot the root directory to index all the files of
- * @param {number} latestNumber the last latest numbered xml file
  * @param {number} newNumber the new latest numbered xml file
  */
-const createOrAppendSiteIndex = async (path, siteMapRoot, latestNumber, newNumber) => {
+const createOrAppendSiteIndex = async (path, siteMapRoot, newNumber) => {
   const siteIndex = await createOrReadXMLAsObject(path, createIndexSkeleton)
+  siteIndex.sitemapindex.sitemap = []
 
-  // Create the first entry in the index if it doesn't exist
-  if (!siteIndex.sitemapindex.sitemap) {
-    const loc = getSiteMapPath(siteMapRoot, latestNumber)
-    siteIndex.sitemapindex.sitemap = [{ loc: convertToAudiusURL(loc) }]
-  }
-
-  // Create new entries in the index if needed based on how many
-  // sitemap files were generated.
-  let i = latestNumber + 1
-  for (i; i <= newNumber; ++i) {
-    console.log(latestNumber, newNumber)
+  // Rewrite the index entries in the sitemap files.
+  for (let i = 1; i <= newNumber; ++i) {
     const newLoc = getSiteMapPath(siteMapRoot, i)
-    if (siteIndex.sitemapindex.sitemap) {
-      // Edge-case:
-      // if there's only one entry, the xml isn't parsed as a list
-      if (!siteIndex.sitemapindex.sitemap.length) {
-        siteIndex.sitemapindex.sitemap = [
-          { loc: siteIndex.sitemapindex.sitemap.loc },
-          { loc: convertToAudiusURL(newLoc) }
-        ]
-      } else {
-        siteIndex.sitemapindex.sitemap.push({
-          loc: convertToAudiusURL(newLoc)
-        })
-      }
-    } else {
-      siteIndex.sitemapindex.sitemap = [{ loc: convertToAudiusURL(newLoc) }]
-    }
+    siteIndex.sitemapindex.sitemap.push({
+      loc: convertToAudiusURL(newLoc)
+    })
   }
 
   const xml = create(siteIndex).end({ prettyPrint: true })
-  fs.writeFile(path, xml, () => {})
+  fs.writeFileSync(path, xml)
 }
 
 /**
@@ -251,7 +229,7 @@ const createSiteDefaults = async (path, config) => {
   map.urlset.url = defaults.routes.map(route => ({ loc: `${ROOT_AUDIUS_URL}${route}` }))
 
   const xml = create(map).end({ prettyPrint: true })
-  fs.writeFile(path, xml, () => {})
+  fs.writeFileSync(path, xml)
 }
 
 module.exports = {


### PR DESCRIPTION
The sitemaps were not being written or do not contain all sub sitemaps
This was due to `fs.writeFile` instead of `fs.writeFileSync` being used right before the program terminated which leads to no file being written.

The `createOrAppendSiteIndex` function appends more sitemaps to the current one, but since it is corrupted, I changed it to re-write the sitemap w/ all the indices. 

See the errors for the current sitemap root 
* https://joe.audius.co/sitemaps/users/index.xml - is an empty file
* https://joe.audius.co/sitemaps/tracks/index.xml - only has sitemap 5.xml